### PR TITLE
Wrap $input_files around quotes

### DIFF
--- a/src/operation-curl.sh
+++ b/src/operation-curl.sh
@@ -9,7 +9,7 @@ case $operation in
       -s \
       -F document_format=$document_format \
       -F document_path=$document_path \
-      -F file=@$input_file \
+      -F file="@$input_file" \
       -F language=$file_language \
       -H 'Authorization: Bearer '"$API_KEY"''
     ;;
@@ -18,7 +18,7 @@ case $operation in
       -s \
       -F document_format=$document_format \
       -F document_path=$document_path \
-      -F file=@$input_file \
+      -F file="@$input_file" \
       -F language=$file_language \
       -F merge_type=$merge_type \
       -H 'Authorization: Bearer '"$API_KEY"''


### PR DESCRIPTION
Fixes the issue with weird path like Xcode's "Supporting Files". 
