### PR TITLE
Add tslib in dependencies instead of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "form-data": "2.3.2",
     "glob": "7.1.2",
     "node-fetch": "2.1.2",
+    "tslib": "1.9.0",
     "tslint-config-prettier": "1.10.0"
   },
   "devDependencies": {
@@ -36,7 +37,6 @@
     "mocha": "5.0.5",
     "prettier": "1.11.1",
     "ts-node": "5",
-    "tslib": "1.9.0",
     "tslint": "5.9.1",
     "typescript": "2.7.2"
   },


### PR DESCRIPTION
The error `Cannot find module 'tslib'` was raised when the developer did not have the package.