### PR TITLE
Check if we got a name to search before actually searching for it

### DIFF
--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -33,9 +33,8 @@ export default class ConfigFetcher {
     nameInConfig: string,
     documentConfigs: DocumentConfig[]
   ) {
-    const documentConfig = documentConfigs.find(
-      ({name}) => name === nameInConfig
-    )
+    const documentConfig =
+      nameInConfig && documentConfigs.find(({name}) => name === nameInConfig)
     if (!documentConfig && nameInConfig) {
       error('No match in your config for this file')
     }


### PR DESCRIPTION
Hey! 

Sooo, this is an attempt to fix #11. Disclaimer, I've not done Typescript before, so there may be a more _typescript'ish_ way to do that? This is only a fix for the issue, I have not added documentation about the `name` property.

I have run:
- `fix`
- `prettier`