### PR TITLE
Allow specifying a sort order for keys when using the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,14 @@ Accent CLI
 <!-- usage -->
 ```sh-session
 $ npm install -g accent-cli
-+ accent-cli@0.4.0
-
 $ accent COMMAND
-…
-
+running command...
 $ accent (-v|--version|version)
-accent-cli/0.3.0 darwin-x64 node-v8.5.0
-
+accent-cli/0.3.0 darwin-x64 node-v11.5.0
 $ accent --help [COMMAND]
 USAGE
   $ accent COMMAND
-  …
+...
 ```
 <!-- usagestop -->
 
@@ -103,6 +99,7 @@ USAGE
 
 OPTIONS
   --mergeType=smart|force|passive  [default: passive]
+  --orderBy=index|key-asc          [default: index]
   --write                          Write the file from the export _after_ the operation
 
 EXAMPLES
@@ -148,7 +145,8 @@ USAGE
   $ accent sync [FILENAME]
 
 OPTIONS
-  --write  Write the file from the export _after_ the operation
+  --orderBy=index|key-asc  [default: index]
+  --write                  Write the file from the export _after_ the operation
 
 EXAMPLES
   $ accent sync

--- a/src/commands/add-translations.ts
+++ b/src/commands/add-translations.ts
@@ -30,6 +30,10 @@ export default class AddTranslations extends Command {
       default: 'passive',
       options: ['smart', 'force', 'passive'],
       required: false
+    }),
+    orderBy: flags.string({
+      default: 'index',
+      options: ['index', 'key-asc']
     })
   }
 
@@ -65,7 +69,7 @@ export default class AddTranslations extends Command {
       await Promise.all(
         document.paths.map(path => {
           formatter.log(path)
-          return document.export(path)
+          return document.export(path, flags)
         })
       )
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,4 +1,5 @@
 // Command
+import {flags} from '@oclif/command'
 import Command from '../base-commit'
 
 // Formatters
@@ -20,7 +21,13 @@ export default class Sync extends Command {
   public static examples = [`$ accent sync`, `$ accent sync Localization-admin`]
 
   public static args = [...Command.args]
-  public static flags = {...Command.flags}
+  public static flags = {
+    ...Command.flags,
+    orderBy: flags.string({
+      default: 'index',
+      options: ['index', 'key-asc']
+    })
+  }
 
   public async run() {
     const {args, flags} = this.parse(Sync)
@@ -54,7 +61,7 @@ export default class Sync extends Command {
       await Promise.all(
         document.paths.map(path => {
           formatter.log(path)
-          return document.export(path)
+          return document.export(path, flags)
         })
       )
 

--- a/src/services/document.ts
+++ b/src/services/document.ts
@@ -67,11 +67,12 @@ export default class Document {
     return this.handleResponse(response, options, OperationName.AddTranslation)
   }
 
-  public async export(file: string) {
+  public async export(file: string, options: any) {
     const query = [
       ['document_path', this.parseDocumentName(file)],
       ['document_format', this.config.format],
-      ['language', this.config.language]
+      ['language', this.config.language],
+      ['order_by', options.orderBy]
     ]
       .map(([name, value]) => `${name}=${value}`)
       .join('&')


### PR DESCRIPTION
This PR add an `orderBy` flag to the `add-translations` and `sync` command.