### PR TITLE
Handle and log fs errors

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -44,8 +44,10 @@ export default class Export extends Command {
 
       await Promise.all(
         targets.map(({path, language, documentPath}) => {
-          formatter.log(path)
-          return document.export(path, language, documentPath, flags)
+          return document
+            .export(path, language, documentPath, flags)
+            .then(() => formatter.log(path))
+            .catch(error => formatter.log(path, error.message))
         })
       )
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -95,8 +95,10 @@ export default class Sync extends Command {
 
       await Promise.all(
         targets.map(({path, language, documentPath}) => {
-          formatter.log(path)
-          return document.export(path, language, documentPath, flags)
+          return document
+            .export(path, language, documentPath, flags)
+            .then(() => formatter.log(path))
+            .catch(error => formatter.log(path, error.message))
         })
       )
 

--- a/src/services/document.ts
+++ b/src/services/document.ts
@@ -123,6 +123,7 @@ export default class Document {
       response.body.pipe(fileStream)
       response.body.on('error', reject)
       fileStream.on('finish', resolve)
+      fileStream.on('error', reject)
     })
   }
 

--- a/src/services/formatters/document-export.ts
+++ b/src/services/formatters/document-export.ts
@@ -2,12 +2,17 @@
 import chalk from 'chalk'
 
 export default class DocumentExportFormatter {
-  public log(path: string) {
+  public log(path: string, error?: string) {
     console.log('  ', chalk.white(path))
-    console.log(
-      '  ',
-      chalk.green('✓ Successfully write the locale files from Accent')
-    )
+    if (error) {
+      console.log('  ', chalk.red('✗ Unable to write the file from Accent'))
+      console.log('  ', chalk.red(error))
+    } else {
+      console.log(
+        '  ',
+        chalk.green('✓ Successfully wrote the locale file from Accent')
+      )
+    }
     console.log('')
   }
 }


### PR DESCRIPTION
I'm opening this to discuss.
When using `accent-cli`, errors during file writing to disk are not handled.

Problem: We have languages in Accent that aren't fully translated. Until those are fully translated, we don't usually create a matching local file. With the current version of `accent-cli`, a failure occurs while writing because the matching locale folder doesn't exist. 

Example of what's currently happening:
```
accent sync --add-translations --order-by=key-asc --write
Fetch config... ✓

Syncing sources

   config/locales/en/main.yml
   ✓ Successfully synced the files in Accent

   config/locales/en/js.yml
   ✓ Successfully synced the files in Accent

Adding translations paths

   config/locales/fr/main.yml
   ✓ Successfully add translations in Accent

   config/locales/fr/js.yml
   ✓ Successfully add translations in Accent

Writing files

   config/locales/en/js.yml
   ✓ Successfully write the locale files from Accent

   config/locales/en/main.yml
   ✓ Successfully write the locale files from Accent

   config/locales/fr/js.yml
   ✓ Successfully write the locale files from Accent

   config/locales/fr/main.yml
   ✓ Successfully write the locale files from Accent

   config/locales/da/js.yml
   ✓ Successfully write the locale files from Accent

   config/locales/da/main.yml
   ✓ Successfully write the locale files from Accent

   config/locales/nl/js.yml
   ✓ Successfully write the locale files from Accent

   config/locales/nl/main.yml
   ✓ Successfully write the locale files from Accent

events.js:173
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open 'config/locales/da/super_admin.yml'
Emitted 'error' event at:
    at errorOrDestroy (internal/streams/destroy.js:98:12)
    at WriteStream.onerror (_stream_readable.js:717:7)
    at WriteStream.emit (events.js:188:13)
    at /Users/louim/.config/yarn/global/node_modules/graceful-fs/graceful-fs.js:228:14
    at /Users/louim/.config/yarn/global/node_modules/graceful-fs/graceful-fs.js:258:16
    at FSReqCallback.args [as oncomplete] (fs.js:147:20)
```
The failure is reported at the end, but the last 4 files failed to write to disk (and possibly other because `Promise.all` is fail-fast). By rejecting the promise on file error and catching errors later it allows us to log it and process other files correctly:

```
accent sync --add-translations --order-by=key-asc --write
Fetch config... ✓

Syncing sources

   config/locales/en/main.yml
   ✓ Successfully synced the files in Accent

   config/locales/en/js.yml
   ✓ Successfully synced the files in Accent

Adding translations paths

   config/locales/fr/main.yml
   ✓ Successfully add translations in Accent

   config/locales/fr/js.yml
   ✓ Successfully add translations in Accent

Writing files

   config/locales/fr/main.yml
   ✓ Successfully wrote the locale file from Accent

   config/locales/en/main.yml
   ✓ Successfully wrote the locale file from Accent

   config/locales/nl/main.yml
   ✗ Unable to write the file from Accent
   ENOENT: no such file or directory, open 'config/locales/nl/main.yml'

   config/locales/da/main.yml
   ✗ Unable to write the file from Accent
   ENOENT: no such file or directory, open 'config/locales/da/main.yml'

   config/locales/nl/js.yml
   ✗ Unable to write the file from Accent
   ENOENT: no such file or directory, open 'config/locales/nl/js.yml'

   config/locales/da/js.yml
   ✗ Unable to write the file from Accent
   ENOENT: no such file or directory, open 'config/locales/da/js.yml'

   config/locales/fr/js.yml
   ✓ Successfully wrote the locale file from Accent

   config/locales/en/js.yml
   ✓ Successfully wrote the locale file from Accent
```

What do you think? 